### PR TITLE
Add VPC for EKS cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,6 @@
 crash.log
 crash.*.log
 
-# Exclude all .tfvars files, which are likely to contain sensitive data
-*.tfvars
-*.tfvars.json
-
 # Ignore override files as they are usually used for local dev
 override.tf
 override.tf.json

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,3 @@
+vpc_cidr_block             = "10.0.0.0/16"
+private_subnet_cidr_blocks = ["10.0.1.0/24"]
+public_subnet_cidr_blocks  = ["10.0.2.0/24"]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,3 @@
+variable vpc_cidr_block {}
+variable private_subnet_cidr_blocks {}
+variable public_subnet_cidr_blocks {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,14 @@
-variable vpc_cidr_block {}
-variable private_subnet_cidr_blocks {}
-variable public_subnet_cidr_blocks {}
+variable "vpc_cidr_block" {
+  type        = string
+  description = "The CIDR block for the VPC"
+}
+
+variable "private_subnet_cidr_blocks" {
+  type        = list(string)
+  description = "List of CIDR blocks for private subnets"
+}
+
+variable "public_subnet_cidr_blocks" {
+  type        = list(string)
+  description = "List of CIDR blocks for public subnets"
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,17 +1,15 @@
-
-
 module "trainstats-vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "5.13.0"
 
-  name = "trainstats-vpc"
-  cidr = var.vpc_cidr_block
+  name            = "trainstats-vpc"
+  cidr            = var.vpc_cidr_block
   private_subnets = var.private_subnet_cidr_blocks
-  public_subnets = var.public_subnet_cidr_blocks
-  azs = ["us-east-1a"]
+  public_subnets  = var.public_subnet_cidr_blocks
+  azs             = ["us-east-1a"]
 
-  enable_nat_gateway = true
-  single_nat_gateway = true
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
   enable_dns_hostnames = true
 
   tags = {
@@ -20,12 +18,11 @@ module "trainstats-vpc" {
 
   public_subnet_tags = {
     "kubernetes.io/cluster/trainstats-eks-cluster" = "shared"
-    "kubernetes.io/role/elb" = 1
+    "kubernetes.io/role/elb"                       = 1
   }
 
   private_subnet_tags = {
     "kubernetes.io/cluster/trainstats-eks-cluster" = "shared"
-    "kubernetes.io/role/internal-elb" = 1
+    "kubernetes.io/role/internal-elb"              = 1
   }
-
 }

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,31 @@
+
+
+module "trainstats-vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.13.0"
+
+  name = "trainstats-vpc"
+  cidr = var.vpc_cidr_block
+  private_subnets = var.private_subnet_cidr_blocks
+  public_subnets = var.public_subnet_cidr_blocks
+  azs = ["us-east-1a"]
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+  enable_dns_hostnames = true
+
+  tags = {
+    "kubernetes.io/cluster/trainstats-eks-cluster" = "shared"
+  }
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/trainstats-eks-cluster" = "shared"
+    "kubernetes.io/role/elb" = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/trainstats-eks-cluster" = "shared"
+    "kubernetes.io/role/internal-elb" = 1
+  }
+
+}


### PR DESCRIPTION
Add VPC for  EKS cluster ( 1 availability zone to keep costs down ) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new variables for configuring CIDR blocks for a Virtual Private Cloud (VPC) and its subnets.
	- Added a new VPC module that creates a structured network environment with private and public subnets, including a NAT gateway and DNS hostname support.
- **Documentation**
	- Enhanced clarity on VPC configuration through the addition of new variables and module descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->